### PR TITLE
fixed access variable reset method

### DIFF
--- a/tools/labs/templates/device_drivers/kernel/so2_cdev.c
+++ b/tools/labs/templates/device_drivers/kernel/so2_cdev.c
@@ -75,7 +75,7 @@ so2_cdev_release(struct inode *inode, struct file *file)
 		(struct so2_device_data *) file->private_data;
 
 	/* TODO 3/1: reset access variable to 0, use atomic_set */
-	atomic_inc(&data->access);
+	atomic_set(&data->access, 0);
 #endif
 	return 0;
 }


### PR DESCRIPTION
Since the exchange value in atomic_cmpxchg is set to 1, atomic_inc will not reset it, and so, the resource will be busy at any second call. atomic_dec, or simply, atomic_set to 0, as implied in the TODO.