### PR TITLE
Documentation: labs: Fix mount device name

### DIFF
--- a/Documentation/teaching/labs/introduction.rst
+++ b/Documentation/teaching/labs/introduction.rst
@@ -497,7 +497,7 @@ Create :file:`/test` directory and try to mount the new disk:
 .. code-block:: bash
 
     mkdir /test
-    mount /dev/sda /test
+    mount /dev/vdd /test
 
 The reason why we can not mount the virtual disk is because we do not have support in the
 kernel for the filesystem with which the :file:`mydisk.img` is formatted. You will need


### PR DESCRIPTION
Because we are using virtio the device name is vd* not sd*. Also,
because it is the fourth disk the name will be /dev/vdd.

Signed-off-by: Diana Ungureanu <diana-gabriela.ungureanu@nxp.com>