### PR TITLE
Use line buffered egrep in pts symlink one-liner of qemu lab script

### DIFF
--- a/tools/labs/qemu/qemu.sh
+++ b/tools/labs/qemu/qemu.sh
@@ -15,7 +15,7 @@ case $ARCH in
 	;;
 esac
 
-echo info chardev | nc -U -l qemu.mon | egrep -o "/dev/pts/[0-9]*" | xargs -I PTS ln -fs PTS serial.pts &
+echo info chardev | nc -U -l qemu.mon | egrep --line-buffered -o "/dev/pts/[0-9]*" | xargs -I PTS ln -fs PTS serial.pts &
 $qemu "$@" -monitor unix:qemu.mon
 rm qemu.mon 
 rm serial.pts


### PR DESCRIPTION
Add the `--line-buffered` command line argument in the egrep call of the qemu terminal symlink (`serial.pts`) one-liner.

This resolves #31 on my Kubuntu 18.04.
