### PR TITLE
teaching: kernel_api: Fix typo in structure name

### DIFF
--- a/Documentation/teaching/labs/kernel_api.rst
+++ b/Documentation/teaching/labs/kernel_api.rst
@@ -684,7 +684,7 @@ free them (in :c:func:`memory_exit`).
       process, with the following information:
 
       * PID of the current process, which can be retrieved from
-        :c:type:`struct task struct` structure, returned by :c:macro:`current`
+        :c:type:`struct task_struct` structure, returned by :c:macro:`current`
         macro.
 
 .. hint::


### PR DESCRIPTION
Signed-off-by: Cristi Done <done.cristian@gmail.com>