### PR TITLE
list: update PROCFS_MAX_SIZE to 512

### DIFF
--- a/tools/labs/templates/assignments/0-list/list.c
+++ b/tools/labs/templates/assignments/0-list/list.c
@@ -13,7 +13,7 @@
 #include <linux/seq_file.h>
 #include <linux/uaccess.h>
 
-#define PROCFS_MAX_SIZE		1024
+#define PROCFS_MAX_SIZE		512
 
 #define procfs_dir_name		"list"
 #define procfs_file_read	"preview"


### PR DESCRIPTION
* CONFIG_FRAME_WARN is set to 1024 and we had a warning that a frame
size was larger than this

Signed-off-by: Claudiu Ghioc <claudiu.ghioc@gmail.com>