### PR TITLE
assignment: 0-list: fix checker script

### DIFF
--- a/Documentation/teaching/labs/introduction.rst
+++ b/Documentation/teaching/labs/introduction.rst
@@ -107,6 +107,8 @@ install both packages and add the following lines to the file
             nmap `<C-\>`f :cs find f `<C-R>`=expand("`<cfile>`")`<CR>``<CR>`
             nmap `<C-\>`i :cs find i ^`<C-R>`=expand("`<cfile>`")`<CR>`$`<CR>`
             nmap `<C-\>`d :cs find d `<C-R>`=expand("`<cword>`")`<CR>``<CR>`
+            nmap <F6> :cnext <CR>
+            nmap <F5> :cprev <CR>
 
             " Open a quickfix window for the following queries.
             set cscopequickfix=s-,c-,d-,i-,t-,e-,g-

--- a/tools/labs/templates/assignments/0-list/checker/_checker
+++ b/tools/labs/templates/assignments/0-list/checker/_checker
@@ -60,7 +60,7 @@ basic_test()
 }
 
 module="list"
-module_file="$module".ko
+module_file=../"$module".ko
 proc_folder="/proc/list"
 preview="$proc_folder/preview"
 management="$proc_folder/management"

--- a/tools/labs/templates/kernel_modules/9-dyndbg/dyndbg.c
+++ b/tools/labs/templates/kernel_modules/9-dyndbg/dyndbg.c
@@ -8,9 +8,9 @@ MODULE_LICENSE("GPL");
 
 void my_debug_func(void)
 {
-	pr_info("Important dyndbg debug message1\n");
-	pr_info("Important dyndbg debug message2\n");
-	pr_info("Verbose dyndbg debug message\n");
+	pr_debug("Important dyndbg debug message1\n");
+	pr_debug("Important dyndbg debug message2\n");
+	pr_debug("Verbose dyndbg debug message\n");
 }
 EXPORT_SYMBOL(my_debug_func);
 


### PR DESCRIPTION
As script is designed, the kernel module is expected to be
    in the same directory as the checker script. Search for it
    one dir back.