### PR TITLE
assignments: 0-list: fix checker script

### DIFF
--- a/tools/labs/templates/assignments/0-list/checker/_checker
+++ b/tools/labs/templates/assignments/0-list/checker/_checker
@@ -60,7 +60,7 @@ basic_test()
 }
 
 module="list"
-module_file="$module".ko
+module_file=../"$module".ko
 proc_folder="/proc/list"
 preview="$proc_folder/preview"
 management="$proc_folder/management"


### PR DESCRIPTION
As script is designed, the kernel module is expected to be
in the same directory as the checker script. Search for it
one dir back.