### PR TITLE
bugfix: stray error 'error: expected declaration specifiers or ‘...’ …

### DIFF
--- a/tools/labs/templates/kernel_modules/3-error-mod/err_mod.c
+++ b/tools/labs/templates/kernel_modules/3-error-mod/err_mod.c
@@ -1,6 +1,5 @@
 #include <linux/init.h>
 #include <linux/kernel.h>
-/* TODO: add missing kernel headers */
 #include <linux/module.h>
 
 MODULE_DESCRIPTION("Error module");


### PR DESCRIPTION
…before string constant'

Signed-off-by: Mrigendra Chaubey <Mrigendra.Chaubey@PathPartnertech.com>