### PR TITLE
tools: labs: qemu: Makefile: Remove deprecated vlan parameter

### DIFF
--- a/tools/labs/qemu/Makefile
+++ b/tools/labs/qemu/Makefile
@@ -19,8 +19,8 @@ QEMU_OPTS = -kernel $(ZIMAGE) \
 	-device virtio-serial \
 	-chardev pty,id=virtiocon0 -device virtconsole,chardev=virtiocon0 \
 	-serial pipe:pipe1 -serial pipe:pipe2 \
-	-net nic,model=virtio,vlan=0 -net tap,ifname=tap0,vlan=0,script=no,downscript=no \
-	-net nic,model=i82559er,vlan=1 -net tap,ifname=tap1,vlan=1,script=no,downscript=no \
+	-netdev tap,id=tap0,ifname=tap0,script=no,downscript=no -net nic,netdev=tap0,model=virtio \
+	-netdev tap,id=tap1,ifname=tap1,script=no,downscript=no -net nic,netdev=tap1,model=i82559er \
 	-drive file=$(YOCTO_IMAGE),if=virtio,format=raw \
 	-drive file=disk1.img,if=virtio,format=raw \
 	-drive file=disk2.img,if=virtio,format=raw \


### PR DESCRIPTION
As of QEMU 3.0 the vlan parameter has been removed, so I had to change the
-net option to -netdev, which has a similar functionality to vlan, ie run the
device in a separate network.

Signed-off-by: Sergiu Weisz <sergiu121@gmail.com>