### PR TITLE
Add support for GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,24 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install packages
+      run: sudo apt install imagemagick graphviz ditaa
+    - name: Build docs
+      run: cd tools/labs && make docs
+    - name: Publish
+      # not yet implemented
+      run: env


### PR DESCRIPTION
Add initial support for building the documentation via GitHub
Actions. Does not yet include support for automatically publishing to
GitHub Pages.

Signed-off-by: Octavian Purdila <tavi@cs.pub.ro>