### PR TITLE
README: Fix README.rst link

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,1 +1,1 @@
-Documentation/labs/index.rst
+Documentation/teaching/index.rst


### PR DESCRIPTION
At some point we renamed Documentation/labs with Documentation/teaching
but did not update README.rst symbolic link. Do it now!

Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>