### PR TITLE
tools/labs/qemu: set USER variable explicitly

### DIFF
--- a/tools/labs/qemu/create_net.sh
+++ b/tools/labs/qemu/create_net.sh
@@ -8,6 +8,8 @@ fi
 
 device=$1
 
+USER=$(whoami)
+
 case "$device" in
     "tap0")
         subnet=172.213.0


### PR DESCRIPTION
When running as root, the USER variable is not set, so we have to set it
explicitly.