### PR TITLE
Fix setup and assignment cleanup in vmchecker scripts

### DIFF
--- a/tools/labs/Makefile.vmchecker
+++ b/tools/labs/Makefile.vmchecker
@@ -25,6 +25,8 @@ extract:
 	sudo cp $(TEMPDIR)/home/root/run-stderr.vmr out/ && sudo chown so2:so2 out/run-stderr.vmr || true
 	sudo umount $(TEMPDIR)
 	rmdir $(TEMPDIR)
+	test -f out/run-stdout.vmr || echo "No testing output (likely due to submission errors)." > out/run-stdout.vmr
+	test -f out/run-stderr.vmr || echo "No testing output (likely due to submission errors)." > out/run-stderr.vmr
 
 destroy:
 	-rm -rf out

--- a/tools/labs/Makefile.vmchecker
+++ b/tools/labs/Makefile.vmchecker
@@ -28,8 +28,11 @@ extract:
 	test -f out/run-stdout.vmr || echo "No testing output (likely due to submission errors)." > out/run-stdout.vmr
 	test -f out/run-stderr.vmr || echo "No testing output (likely due to submission errors)." > out/run-stderr.vmr
 
+postprocess:
+	sed -i '/^Linux version /,/^netconsole: network logging started/d' out/run-km.vmr
+
 destroy:
 	-rm -rf out
 	-rm -f $(YOCTO_IMAGE)
 
-.PHONY: setup copy extract destroy
+.PHONY: setup copy extract postprocess destroy

--- a/tools/labs/scripts/so2-startup-script
+++ b/tools/labs/scripts/so2-startup-script
@@ -7,7 +7,7 @@ ip a a dev eth0 172.213.0.7/24
 ip l set dev eth0 up
 sleep 1
 
-modprobe netconsole netconsole=6666@172.213.0.7/eth0,6666@172.213.0.1/46:f6:04:29:d8:72
+modprobe netconsole netconsole=6666@172.213.0.7/eth0,6666@172.213.0.1/
 
 dmesg -n 8
 dmesg -c /dev/null 2>&1

--- a/tools/labs/scripts/vmchecker-setup
+++ b/tools/labs/scripts/vmchecker-setup
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 if test ! -f ../initial.clean-slate.core-image-minimal-qemux86.ext4; then
-    cp ../core-image-minimal-qemux86.ext4 ../initial.clean-slate.core-image-minimal-qemux86.ext4
+    wget http://downloads.yoctoproject.org/releases/yocto/yocto-2.3/machines/qemu/qemux86/core-image-minimal-qemux86.ext4 -O ../initial.clean-slate.core-image-minimal-qemux86.ext4
 fi
 if test ! -f ../clean-slate.core-image-minimal-qemux86.ext4; then
     cp ../initial.clean-slate.core-image-minimal-qemux86.ext4 ../clean-slate.core-image-minimal-qemux86.ext4

--- a/tools/labs/scripts/vmchecker-setup
+++ b/tools/labs/scripts/vmchecker-setup
@@ -4,7 +4,7 @@ if test ! -f ../initial.clean-slate.core-image-minimal-qemux86.ext4; then
     cp ../core-image-minimal-qemux86.ext4 ../initial.clean-slate.core-image-minimal-qemux86.ext4
 fi
 if test ! -f ../clean-slate.core-image-minimal-qemux86.ext4; then
-    cp ../core-image-minimal-qemux86.ext4 ../clean-slate.core-image-minimal-qemux86.ext4
+    cp ../initial.clean-slate.core-image-minimal-qemux86.ext4 ../clean-slate.core-image-minimal-qemux86.ext4
     sudo ./install-startup-script ../clean-slate.core-image-minimal-qemux86.ext4
 fi
 if test ! -d ../out/; then


### PR DESCRIPTION
Fix issues in vmchecker scripts and Makefile (`Makefile.vmchecker`):
* the clean slate image is now created from the initial image (not wrongly from the running image)
* create placeholder output files in case they are absent (`run-stdout.vmr` and `run-stderr.vmr`)
* postprocess kernel messages file to only show relevant information