### PR TITLE
templates: 6-list-sync: Fix potential dangling pointer

### DIFF
--- a/tools/labs/templates/kernel_api/6-list-sync/list-sync.c
+++ b/tools/labs/templates/kernel_api/6-list-sync/list-sync.c
@@ -46,18 +46,12 @@ static struct task_info *task_info_find_pid(int pid)
 	struct list_head *p;
 	struct task_info *ti;
 
-	/* TODO 1: Protect list, is this read or write access? */
-	read_lock(&lock);
 	list_for_each(p, &head) {
 		ti = list_entry(p, struct task_info, list);
 		if (ti->pid == pid) {
-			/* TODO: Guess why this comment was added  here */
-			read_unlock(&lock);
 			return ti;
 		}
 	}
-	/* TODO 1: critical section ends here */
-	read_unlock(&lock);
 
 	return NULL;
 }
@@ -66,12 +60,18 @@ static void task_info_add_to_list(int pid)
 {
 	struct task_info *ti;
 
+	/* TODO 1: Protect list, is this read or write access? */
+	write_lock(&lock);
 	ti = task_info_find_pid(pid);
 	if (ti != NULL) {
 		ti->timestamp = jiffies;
 		atomic_inc(&ti->count);
+		/* TODO: Guess why this comment was added  here */
+		write_unlock(&lock);
 		return;
 	}
+	/* TODO 1: critical section ends here */
+	write_unlock(&lock);
 
 	ti = task_info_alloc(pid);
 	/* TODO 1: protect list access, is this read or write access? */


### PR DESCRIPTION
As soon as the lock is unlocked in `task_info_find_pid`,
the caller cannot be sure if the pointer that is returned is valid.
As long as the returned pointer is used, the lock must be held.

In the case of `task_info_add_to_list`, the lock that must be held is a writer lock,
in case of a reader lock other readers could read an inconsistent state of the `struct task_info`.