### PR TITLE
tools: labs: Ignore all Yocto image files

### DIFF
--- a/tools/labs/.gitignore
+++ b/tools/labs/.gitignore
@@ -5,6 +5,6 @@ serial.pts
 rootfs.img
 disk1.img
 disk2.img
-/*core-image-minimal-*.ext4
+/*core-image-*.ext4
 .modinst
 /out/


### PR DESCRIPTION
Up until this commit only `core-image-miminal-*` Yocto image files were ignored.  Others, such as `core-image-sato-*` Yocto image files were not. This commit fixes that, will al Yocto image files being ignored.