### PR TITLE
minfs_write_inode uid/gid issue

### DIFF
--- a/tools/labs/templates/filesystems/minfs/kernel/minfs.c
+++ b/tools/labs/templates/filesystems/minfs/kernel/minfs.c
@@ -470,8 +470,8 @@ static int minfs_write_inode(struct inode *inode,
 
 	/* fill disk inode */
 	mi->mode = inode->i_mode;
-	i_uid_write(inode, mi->uid);
-	i_gid_write(inode, mi->gid);
+	mi->uid = i_uid_read(inode);
+	mi->gid = i_gid_read(inode);
 	mi->size = inode->i_size;
 	mi->data_block = mii->data_block;
 


### PR DESCRIPTION
`minfs_write_inode` should fill the disk inode with the aquired `uid` and `gid` from the inode, not the other way round.

Please check the `minix` solution below:
https://elixir.bootlin.com/linux/latest/source/fs/minix/inode.c#L557