### PR TITLE
tools/labs: Add clean target to all Makefiles

### DIFF
--- a/tools/labs/templates/deferred_work/3-4-5-deferred/user/Makefile
+++ b/tools/labs/templates/deferred_work/3-4-5-deferred/user/Makefile
@@ -2,3 +2,8 @@ CFLAGS=-Wall -m32
 LDFLAGS=-static -m32
 
 test: test.o
+
+.PHONY: clean
+
+clean:
+	-rm -f *~ *.o test

--- a/tools/labs/templates/device_drivers/user/Makefile
+++ b/tools/labs/templates/device_drivers/user/Makefile
@@ -1,2 +1,7 @@
 all: so2_cdev_test.c
 	gcc -m32 -static -o so2_cdev_test so2_cdev_test.c
+
+.PHONY: clean
+
+clean:
+	-rm -f *~ *.o so2_cdev_test

--- a/tools/labs/templates/memory_mapping/test/Makefile
+++ b/tools/labs/templates/memory_mapping/test/Makefile
@@ -2,3 +2,8 @@ CFLAGS=-Wall -m32
 LDFLAGS=-static -m32
 
 mmap-test: mmap-test.o
+
+.PHONY: clean
+
+clean:
+	-rm -f *~ *.o mmap-test


### PR DESCRIPTION
The clean rule failed for some labs because the clean target wasn't defined in all the makefiles. This PR adds it to all the make files.

Signed-off-by: Sergiu Weisz <sergiu121@gmail.com>