### PR TITLE
labs: networking: Fix includes in userspace component

### DIFF
--- a/tools/labs/templates/networking/1-2-netfilter/user/test.c
+++ b/tools/labs/templates/networking/1-2-netfilter/user/test.c
@@ -11,6 +11,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/ioctl.h>
+#include <sys/sysmacros.h>
 #include <fcntl.h>
 #include <unistd.h>
 #include <netinet/in.h>


### PR DESCRIPTION
For the `makedev` macro in newer versions of Glibc (since v2.28) we need
to directly include <sys/sysmacros.h>, because that is no longer
included by <sys/types>.

Fix by including the correct header.

Signed-off-by: Paul-Stelian Olaru <paul_stelian.olaru@stud.acs.upb.ro>