### PR TITLE
Documentation/teaching: Fix remaining '~/so2' in contributing.rst

### DIFF
--- a/Documentation/teaching/info/contributing.rst
+++ b/Documentation/teaching/info/contributing.rst
@@ -69,7 +69,7 @@ Forking the repository
 
    .. code-block:: bash
 
-     $ mkdir -p ~/so2
+     $ mkdir -p ~/src
      $ git clone git@github.com:linux-kernel-labs/linux.git ~/src/linux
 
 2. Go to https://github.com/linux-kernel-labs/linux, make sure you are logged


### PR DESCRIPTION
Commit 44b5f01651c4 ("Documentation/teaching: Use 'src/linux' instead of
'so2/linux'") missed fixing directory creation command.  This commit
fixes it.

Signed-off-by: SeongJae Park <sj38.park@gmail.com>