### PR TITLE
documentation: removed `inte i` from code block

### DIFF
--- a/Documentation/teaching/labs/block_device_drivers.rst
+++ b/Documentation/teaching/labs/block_device_drivers.rst
@@ -743,7 +743,6 @@ A typical example of use is:
 
    static int my_xfer_bio(struct my_block_dev *dev, struct bio *bio)
    {
-       int i;
        struct bio_vec bvec;
        struct bvec_iter i;
        int dir = bio_data_dir(bio);


### PR DESCRIPTION
the `inte i;` here clashes with `struct bvec_iter i;` and is not used