### PR TITLE
tools: labs: Remove oldnoconfig target

### DIFF
--- a/tools/labs/qemu/Makefile
+++ b/tools/labs/qemu/Makefile
@@ -34,7 +34,7 @@ TEMPDIR := $(shell mktemp -u)
 
 $(KCONFIG): qemu/kernel_config.x86
 	cp $^ $@
-	$(MAKE) -C $(KDIR) oldnoconfig
+	$(MAKE) -C $(KDIR) olddefconfig
 
 zImage: $(ZIMAGE)
 


### PR DESCRIPTION
As commit 312ee68752fa ("kconfig: announce removal of oldnoconfig if
used") announced, remove oldnoconfig target.

Signed-off-by: Daniel Baluta <daniel.baluta@nxp.com>