### PR TITLE
labs: kernel_modules: use proc_ops when calling proc_create

### DIFF
--- a/tools/labs/templates/kernel_modules/8-kdb/hello_kdb.c
+++ b/tools/labs/templates/kernel_modules/8-kdb/hello_kdb.c
@@ -101,32 +101,30 @@ static int bug_write(struct file *file, const char *buffer,
 	return count;
 }
 
-static const struct file_operations edit_proc_fops = {
-	.owner = THIS_MODULE,
-	.open = hello_proc_open,
-	.read = seq_read,
-	.write = edit_write,
-	.llseek = seq_lseek,
-	.release = single_release,
+static const struct proc_ops edit_proc_ops = {
+	.proc_open	= hello_proc_open,
+	.proc_read	= seq_read,
+	.proc_write	= edit_write,
+	.proc_lseek	= seq_lseek,
+	.proc_release	= single_release,
 };
 
-static const struct file_operations bug_proc_fops = {
-	.owner = THIS_MODULE,
-	.open = hello_proc_open,
-	.read = seq_read,
-	.write = bug_write,
-	.llseek = seq_lseek,
-	.release = single_release,
+static const struct proc_ops bug_proc_ops = {
+	.proc_open	= hello_proc_open,
+	.proc_read	= seq_read,
+	.proc_write	= bug_write,
+	.proc_lseek	= seq_lseek,
+	.proc_release	= single_release,
 };
 
 static int __init hello_proc_init(void) {
 	struct proc_dir_entry *file;
-	file = proc_create("hello_kdb_bug", 0, NULL, &bug_proc_fops);
+	file = proc_create("hello_kdb_bug", 0, NULL, &bug_proc_ops);
 	if (file == NULL) {
 		return -ENOMEM;
 	}
 
-	file = proc_create("hello_kdb_break", 0, NULL, &edit_proc_fops);
+	file = proc_create("hello_kdb_break", 0, NULL, &edit_proc_ops);
 	if (file == NULL) {
 		remove_proc_entry("hello_kdb_bug", NULL);
 		return -ENOMEM;


### PR DESCRIPTION
* use proc_ops instead of file_operations

Signed-off-by: Claudiu Ghioc <claudiu.ghioc@gmail.com>