### PR TITLE
Update the <Good to know> label for cross referencing

### DIFF
--- a/Documentation/teaching/so2/lab1-intro.rst
+++ b/Documentation/teaching/so2/lab1-intro.rst
@@ -48,7 +48,7 @@ Lab objectives
 .. note::
 
     If you want to learn how to easily browse through the Linux source code
-    and how to debug kernel code, read the `Good to know <#good_to_know>`__
+    and how to debug kernel code, read the `Good to know <#good-to-know>`__
     section.
 
 Exercises
@@ -95,7 +95,7 @@ Exercises
     :start-after: [EXERCISE7-BEGIN]
     :end-before: [EXERCISE7-END]
 
-.. _good_to_know:
+.. _good-to-know:
 
 Good to know
 ============


### PR DESCRIPTION
**Issue**:
Sphinx replaces underscores in label names with dashes, hence the reference to the Good to know section from the Note above [Exercises](https://linux-kernel-labs.github.io/refs/heads/master/so2/lab1-intro.html#exercises)  doesn't work.

E.g.
```
File: linux/Documentation/teaching/so2/lab1-intro.rst
.. _good_to_know:

Good to know
============
```

```
File: linux/Documentation/output/teaching/so2/lab1-intro.rst
<div class="section" id="good-to-know">
```
