### PR TITLE
labs: kernel_api: fix skel build for kernel_api lab

### DIFF
--- a/Documentation/teaching/labs/kernel_api.rst
+++ b/Documentation/teaching/labs/kernel_api.rst
@@ -831,6 +831,8 @@ module. It will call functions exported by the **6-list-sync**
 task. The exported functions are the ones marked with **extern** in
 :file:`list-test.c` file.
 
+Uncomment the commented code from :file:`7-list-test.c`. Look for ``TODO 1``.
+
 To export the above functions from the module located at :file:`6-list-sync/`
 directory, the following steps are required:
 

--- a/tools/labs/templates/kernel_api/7-list-test/list-test.c
+++ b/tools/labs/templates/kernel_api/7-list-test/list-test.c
@@ -16,16 +16,18 @@ extern void task_info_print_list(const char *msg);
 
 static int list_test_init(void)
 {
-	task_info_add_for_current();
-	task_info_print_list("after new addition");
+	/* TODO 1/0: Uncomment after exporting the symbols in 6-list-sync. */
+	// task_info_add_for_current();
+	// task_info_print_list("after new addition");
 
 	return 0;
 }
 
 static void list_test_exit(void)
 {
-	task_info_remove_expired();
-	task_info_print_list("after removing expired");
+	/* TODO 1/0: Uncomment after exporting the symbols in 6-list-sync. */
+	// task_info_remove_expired();
+	// task_info_print_list("after removing expired");
 }
 
 module_init(list_test_init);


### PR DESCRIPTION
Functions used in 7-list-test.c are not exported by default, this is only done after solving exercise 6.

Signed-off-by: Valentin Ghita <valx92@gmail.com>