### PR TITLE
Documentation: teaching: Add clangd to code navigation section

### DIFF
--- a/Documentation/teaching/labs/introduction.rst
+++ b/Documentation/teaching/labs/introduction.rst
@@ -179,6 +179,30 @@ These commands will activate cscope for the C and C++ modes automatically.
 search for a symbol (if you call it when the cursor is over a word,
 it will use that). For more details, check `https://github.com/dkogan/xcscope.el`
 
+clangd
+------
+
+`Clangd <https://clangd.llvm.org/>`__ is a language server that provides tools
+for navigating C and C++ code. 
+`Language Server Protocol <https://microsoft.github.io/language-server-protocol/>`__
+facilitates features like go-to-definition, find-references, hover, completion, etc.,
+using semantic whole project analysis.
+
+Clangd requires a compilation database to understand the kernel source code.
+It can be generated with:
+
+.. code-block:: bash
+
+    make defconfig
+    make
+    scripts/clang-tools/gen_compile_commands.py
+
+LSP clients:
+
+- Vim/Neovim (`coc.nvim <https://github.com/neoclide/coc.nvim>`__, `nvim-lsp <https://github.com/neovim/nvim-lspconfig>`__, `vim-lsc <https://github.com/natebosch/vim-lsc>`__, `vim-lsp <https://github.com/prabirshrestha/vim-lsp>`__)
+- Emacs (`lsp-mode <https://github.com/emacs-lsp/lsp-mode>`__)
+- VSCode (`clangd extension <https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.vscode-clangd>`__)
+
 Kscope
 ~~~~~~
 

--- a/Documentation/teaching/labs/introduction.rst
+++ b/Documentation/teaching/labs/introduction.rst
@@ -204,7 +204,7 @@ LSP clients:
 - VSCode (`clangd extension <https://marketplace.visualstudio.com/items?itemName=llvm-vs-code-extensions.vscode-clangd>`__)
 
 Kscope
-~~~~~~
+------
 
 For a simpler interface, `Kscope <http://sourceforge.net/projects/kscope/>`__
 is a cscope frontend which uses QT. It is lightweight, very fast and very


### PR DESCRIPTION
Clangd is a language server that facilitates easy navigation and completion
of C code. It think it would be useful to mention it in the code navigation section, given that [support](https://patchwork.kernel.org/project/linux-kbuild/patch/20181206222318.218157-1-tmroeder@google.com/) for it has been added for some time now.
