### PR TITLE
Fix process sleep in the cdev driver

### DIFF
--- a/tools/labs/templates/device_drivers/kernel/so2_cdev.c
+++ b/tools/labs/templates/device_drivers/kernel/so2_cdev.c
@@ -65,7 +65,7 @@ static int so2_cdev_open(struct inode *inode, struct file *file)
 		return -EBUSY;
 
 	set_current_state(TASK_INTERRUPTIBLE);
-	schedule_timeout(10);
+	schedule_timeout(10 * HZ);
 
 	return 0;
 }


### PR DESCRIPTION
schedule_timeout expect the timeout value in jiffies. To pass the value
in seconds, we need to multiply in by the constant HZ.

Signed-off-by: Wander Lairson Costa <wander.lairson@gmail.com>