### PR TITLE
3-4-5-deferred: fix sizeof of pointer allocation

### DIFF
--- a/tools/labs/templates/deferred_work/3-4-5-deferred/kernel/deferred.c
+++ b/tools/labs/templates/deferred_work/3-4-5-deferred/kernel/deferred.c
@@ -67,7 +67,7 @@ static struct mon_proc *get_proc(pid_t pid)
 	if (!task)
 		return ERR_PTR(-ESRCH);
 
-	p = kmalloc(sizeof(p), GFP_ATOMIC);
+	p = kmalloc(sizeof(*p), GFP_ATOMIC);
 	if (!p)
 		return ERR_PTR(-ENOMEM);
 


### PR DESCRIPTION
sizeof(p) allocates only the size of pointer, we should use sizeof(*p)
to allocate the size of the structure.