### PR TITLE
Fix automated (vmchecker) testing for network assignments

### DIFF
--- a/tools/labs/scripts/so2-startup-script
+++ b/tools/labs/scripts/so2-startup-script
@@ -6,6 +6,7 @@ echo "SO2 checker starts ..." > /so2-checker.debug
 ip a a dev eth0 172.213.0.7/24
 ip l set dev eth0 up
 sleep 1
+ip l set dev lo up
 
 modprobe netconsole netconsole=6666@172.213.0.7/eth0,6666@172.213.0.1/
 
@@ -19,7 +20,7 @@ date > /dev/hvc0
 date >> /so2-checker.debug
 
 cd /home/root
-/bin/sh ./run.sh > /dev/hvc0
+/bin/sh ./run.sh > /dev/hvc0 < /dev/null
 
 echo "Testing complete." > /dev/hvc0
 echo "Testing complete." >> /so2-checker.debug


### PR DESCRIPTION
Assignment testing is done automatically via vmchecker. This is done
with the help of the `so2-startup-script` placed in `/etc/init.d/so2`
and then symlinked in `/etc/rcX.d/99so2` (X = 1..6).

For networking assignments (i.e. the STP - Simple Transport Protocol),
two issues prevent proper testing:

1. Because there is no terminal, standard file descriptors (0, 1, 2) are
not initialized. If no redirection is used, then these file descriptors
(0, for example) will be used for socket descriptors. Tests for socket()
calls assume returned socket file descriptors are > 0. This is fixed by
redirecting standard input from `/dev/null`, thus initializing the
standard input file descriptor (0).

2. The loopback interface is not initialized. Tests using send/receive
calls fails. This is fixed by enabling the loopback interface (`lo`).

Issue 1 could be fixed by updating the test and not redirecting input from `/dev/null`. What do you think is the best way to handle this?