### PR TITLE
Documentation: Fix Example Causing Page Fault

### DIFF
--- a/Documentation/teaching/labs/block_device_drivers.rst
+++ b/Documentation/teaching/labs/block_device_drivers.rst
@@ -513,8 +513,8 @@ An example of using these functions is as follows:
    static void delete_block_device(struct block_dev *dev)
    {
        //...
-       blk_mq_free_tag_set(&dev->tag_set);
        blk_cleanup_queue(dev->queue);
+       blk_mq_free_tag_set(&dev->tag_set);
    }
 
    static void my_block_exit(void)


### PR DESCRIPTION
After freeing the tag set, deleting the queue will result in a page fault.
Therefore the order is:
```
blk_cleanup_queue(dev->queue);
blk_mq_free_tag_set(&dev->tag_set);
```

Signed-off-by: Andrei David <dandrei279@gmail.com>