### PR TITLE
networking.rst: tcp_hdr restrictions pre 3.11-rc2

### DIFF
--- a/Documentation/teaching/labs/networking.rst
+++ b/Documentation/teaching/labs/networking.rst
@@ -856,7 +856,8 @@ Registering/unregistering a hook is done using the functions defined in
 
 .. attention::
 
-  There are some restrictions related to the use of header extraction functions
+  Prior to version 3.11-rc2 of the Linux kernel,
+  there are some restrictions related to the use of header extraction functions
   from a :c:type:`struct sk_buff` structure set as a parameter in a netfilter
   hook. While the IP header can be obtained each time using :c:func:`ip_hdr`,
   the TCP and UDP headers can be obtained with :c:func:`tcp_hdr` and


### PR DESCRIPTION
first, thanks - the documentation here is quite helpful.

while using it, I came across (a warning)[https://linux-kernel-labs.github.io/refs/heads/master/labs/networking.html#netfilter-1] which worked, so I looked into it and it was changed. (commit 21d1196a35f5686c4323e42a62fdb4b23b0ab4a3),
and I think the documentation here should reflect that too.
