### PR TITLE
Fix compilation with new gcc versions and other small fixes

### DIFF
--- a/Documentation/teaching/labs/deferred_work.rst
+++ b/Documentation/teaching/labs/deferred_work.rst
@@ -180,8 +180,8 @@ Tasklets can be masked and the following functions can be used:
 
 .. code-block:: c
 
-   void tasklet_enable(struct tasklet_struct * tasklet );
-   void tasklet_disable(struct tasklet_struct * tasklet );
+   void tasklet_enable(struct tasklet_struct * tasklet);
+   void tasklet_disable(struct tasklet_struct * tasklet);
 
 Remember that since tasklets are running from softirqs, blocking calls
 can not be used in the handler function.

--- a/Documentation/teaching/labs/interrupts.rst
+++ b/Documentation/teaching/labs/interrupts.rst
@@ -801,7 +801,7 @@ section before proceeding.
 Follow the sections maked with **TODO 2** in the skeleton.
 
 First, define an empty interrupt handling routine named
-c:func:`kbd_interrupt_handler`.
+:c:func:`kbd_interrupt_handler`.
 
 .. note:: Since we already have a driver that uses this interrupt we
 	  should report the interrupt as not handled (i.e. return

--- a/Documentation/teaching/labs/networking.rst
+++ b/Documentation/teaching/labs/networking.rst
@@ -797,7 +797,7 @@ where:
   * ``hook`` is the handler called when capturing a network packet (packet sent
     as a :c:type:`struct sk_buff` structure). The ``private`` field is private information
     handed to the handler. The capture handler prototype is defined by the
-    :c:type:`struct nf_hookfn` type:
+    :c:type:`nf_hookfn` type:
 
 .. code-block:: c
 

--- a/Documentation/teaching/lectures/fs.rst
+++ b/Documentation/teaching/lectures/fs.rst
@@ -110,8 +110,8 @@ abstractions are depicted.
 Multiple file descriptors can point to the same *file* because we can
 use the :c:func:`dup` system call to duplicate a file descriptor.
 
-Multiple *file* abstractions can point to the same *dentry* if we the
-same path multiple times.
+Multiple *file* abstractions can point to the same *dentry* if we open
+the same path multiple times.
 
 Multiple *dentries* can point to the same *inode* when hard links are
 used.

--- a/Documentation/teaching/lectures/interrupts.rst
+++ b/Documentation/teaching/lectures/interrupts.rst
@@ -819,7 +819,7 @@ checks are not put into place. Currently, the Linux kernel does not allow
 running soft irqs for more than :c:macro:`MAX_SOFTIRQ_TIME` or rescheduling for
 more than :c:macro:`MAX_SOFTIRQ_RESTART` consecutive times.
 
-Once these limits are reached a special kernel thread, **ksoftirqd** is wake-up
+Once these limits are reached a special kernel thread, **ksoftirqd** is woken up
 and all of the rest of pending soft irqs will be run from the context of this
 kernel thread.
 

--- a/Documentation/teaching/lectures/memory-management.rst
+++ b/Documentation/teaching/lectures/memory-management.rst
@@ -241,8 +241,8 @@ Small allocations
      geometric distribution of caches with fixed-size can be used
 
    * Reduces the memory allocation foot-print since we are searching a
-     much smaller memory area - object caches are, compared to buddy
-     which can span over a larger area
+     much smaller memory area, compared to buddy which can span over a
+     larger area
 
    * Employs cache optimization techniques (slab coloring)
 

--- a/Documentation/teaching/lectures/processes.rst
+++ b/Documentation/teaching/lectures/processes.rst
@@ -736,7 +736,7 @@ Blocking the current thread
 
 Blocking the current thread is an important operation we need to
 perform to implement efficient task scheduling - we want to run other
-treads while I/O operations complete.
+threads while I/O operations complete.
 
 In order to accomplish this the following operations take place:
 

--- a/Documentation/teaching/lectures/processes.rst
+++ b/Documentation/teaching/lectures/processes.rst
@@ -1158,7 +1158,7 @@ needed the scheduler is called to select a new task.
 Process context
 ===============
 
-Now that we have examined the implementation on processed and threads
+Now that we have examined the implementation of processes and threads
 (tasks), how context switching occurs, how we can block, wake-up and
 preempt tasks, we can finally define what the process context is what
 are its properties:

--- a/tools/labs/templates/interrupts/kbd.c
+++ b/tools/labs/templates/interrupts/kbd.c
@@ -223,7 +223,7 @@ static int kbd_init(void)
 	}
 	if (request_region(I8042_STATUS_REG+1, 1, MODULE_NAME) == NULL) {
 		err = -EBUSY;
-		goto out_unregister;
+		goto out_release_region;
 	}
 
 	/* TODO 3: initialize spinlock */
@@ -244,9 +244,10 @@ static int kbd_init(void)
 	pr_notice("Driver %s loaded\n", MODULE_NAME);
 	return 0;
 
-	/*TODO 2/3: release regions in case of error */
+	/*TODO 2/4: release regions in case of error */
 out_release_regions:
 	release_region(I8042_STATUS_REG+1, 1);
+out_release_region:
 	release_region(I8042_DATA_REG+1, 1);
 
 out_unregister:

--- a/tools/lib/subcmd/subcmd-util.h
+++ b/tools/lib/subcmd/subcmd-util.h
@@ -50,15 +50,8 @@ static NORETURN inline void die(const char *err, ...)
 static inline void *xrealloc(void *ptr, size_t size)
 {
 	void *ret = realloc(ptr, size);
-	if (!ret && !size)
-		ret = realloc(ptr, 1);
-	if (!ret) {
-		ret = realloc(ptr, size);
-		if (!ret && !size)
-			ret = realloc(ptr, 1);
-		if (!ret)
-			die("Out of memory, realloc failed");
-	}
+	if (!ret)
+		die("Out of memory, realloc failed");
 	return ret;
 }
 


### PR DESCRIPTION
Backport a patch from [Kees Cook](
https://github.com/torvalds/linux/commit/52a9dab6d892763b2a8334a568bd4e2c1a6fde66) that fixes a compilation _error_ on presumably new versions of `gcc` (I got hit by this while running `gcc version 12.2.0 (GCC)`).

And a couple of small fixes.