### PR TITLE
tools: labs: qemu: use pci=noacpi

### DIFF
--- a/tools/labs/qemu/Makefile
+++ b/tools/labs/qemu/Makefile
@@ -24,7 +24,7 @@ QEMU_OPTS = -kernel $(ZIMAGE) \
 	-drive file=$(YOCTO_IMAGE),if=virtio,format=raw \
 	-drive file=disk1.img,if=virtio,format=raw \
 	-drive file=disk2.img,if=virtio,format=raw \
-	--append "root=/dev/vda loglevel=15 console=hvc0" \
+	--append "root=/dev/vda loglevel=15 console=hvc0 pci=noacpi" \
 	--display $(QEMU_DISPLAY) -s -m 256
 
 ifdef ENABLE_KVM


### PR DESCRIPTION
Pass pci=noacpi to the kernel command line to work-around and issue where the boot process get stuck while discovering PCI interrupt links:

[    2.846955] ACPI: Power Button [PWRF]
[    9.749737] PCI Interrupt Link [LNKC] enabled at IRQ 11
[   16.426134] PCI Interrupt Link [LNKA] enabled at IRQ 10
[   22.859276] PCI Interrupt Link [LNKB] enabled at IRQ 10
[   28.869926] rcu: INFO: rcu_sched detected stalls on CPUs/tasks:
[   28.869926] 	(detected by 0, t=6502 jiffies, g=-891, q=521853)
[   28.869926] rcu: All QSes seen, last rcu_sched kthread activity 6502 (-67832--74334), jiffies_till_next_fqs=1, root ->qsmask 0x0
[   28.869926] rcu: rcu_sched kthread starved for 6502 jiffies! g-891 f0x2 RCU_GP_WAIT_FQS(5) ->state=0x0 ->cpu=0
[   28.869926] rcu: 	Unless rcu_sched kthread gets sufficient CPU time, OOM is now expected behavior.
[   28.869926] rcu: RCU grace-period kthread stack dump:
[   28.869926] task:rcu_sched       state:R  running task     stack:    0 pid:   10 ppid:     2 flags:0x00004000
[   28.869926] Call Trace:
[   28.869926]  __schedule+0x23f/0x760
[   28.869926]  ? __mod_timer+0x1ed/0x320
[   28.869926]  schedule+0x56/0xd0
[   28.869926]  schedule_timeout+0xaa/0x1c0
[   28.869926]  ? trace_raw_output_hrtimer_start+0xa0/0xa0
[   28.869926]  rcu_gp_kthread+0x551/0x1240
[   28.869926]  ? __kthread_parkme+0x62/0x80
[   28.869926]  ? trace_hardirqs_on+0x2b/0xe0
[   28.869926]  ? __kthread_parkme+0x43/0x80
[   28.869926]  kthread+0x105/0x120
[   28.869926]  ? rcu_core_si+0x10/0x10
[   28.869926]  ? kthread_create_worker_on_cpu+0x20/0x20
[   28.869926]  ret_from_fork+0x1c/0x28
[   35.677901] PCI Interrupt Link [LNKD] enabled at IRQ 11

This significantly reduces the start-up time for the emulator. Before:

[   41.979421] Run /sbin/init as init process

After:

[    4.713282] Run /sbin/init as init process