### PR TITLE
Solve `make console` bugs for docker

### DIFF
--- a/tools/labs/docker/kernel/Dockerfile
+++ b/tools/labs/docker/kernel/Dockerfile
@@ -30,6 +30,8 @@ RUN apt-get install -y libssl-dev
 RUN apt-get install -y git ninja-build pkg-config libglib2.0-dev libpixman-1-dev
 RUN apt-get install -y lzop
 
+RUN apt-get install -y samba # for the new make console command
+
 RUN apt-get -y clean
 
 RUN rm -rf /var/lib/apt/lists/*

--- a/tools/labs/qemu/run-qemu.sh
+++ b/tools/labs/qemu/run-qemu.sh
@@ -33,7 +33,9 @@ esac
 smbd=${SMBD:-"smbd"}
 
 qemu=${QEMU:-"qemu-system-$qemu_arch"}
-qemu_kvm=${QEMU_KVM:-"-enable-kvm -cpu host"}
+if kvm-ok; then
+	qemu_kvm=${QEMU_KVM:-"-enable-kvm -cpu host"}
+fi
 qemu_cpus=${QEMU_CPUS:-"1"}
 qemu_mem=${QEMU_MEM:-"512"}
 qemu_display=${QEMU_DISPLAY:-"$qemu_display"}


### PR DESCRIPTION
In this commit, I added a rule to install samba in the docker because it is required by the new setup. And I removed the qemu_kvm variable from the qemu/run-qemu.sh script when kvm is not available (It is easier this way than setting the QEMU_KVM environment variable).