### PR TITLE
run-qemu: use absolute paths

### DIFF
--- a/tools/labs/qemu/run-qemu.sh
+++ b/tools/labs/qemu/run-qemu.sh
@@ -30,10 +30,10 @@ case "$arch" in
     *) echo "unknown architecture '$arch'" >&2; exit 1 ;;
 esac
 
-smbd=${SMBD:-"smbd"}
+smbd=${SMBD:-"/usr/sbin/smbd"}
 
 qemu=${QEMU:-"qemu-system-$qemu_arch"}
-if kvm-ok; then
+if /usr/sbin/kvm-ok; then
 	qemu_kvm=${QEMU_KVM:-"-enable-kvm -cpu host"}
 fi
 qemu_cpus=${QEMU_CPUS:-"1"}


### PR DESCRIPTION
Hello,

I had a problem when running for the first time `make console` in `tools/labs`. My shell interpreter couldn't find the path to `smbd` and `kvm-ok`.

This can be solved in two steps:

1. Install `samba` and `cpu-checker`
2. Specify the absolute paths for the utilities in the `run-qemu.sh` script.

What do you think of this? Should there be added a dependencies specification in the labs introduction?  

*Disclaimer*: I am using Debian 11 (stable).