### PR TITLE
Doc/teaching/lab/kernel_modules: Fix typos

### DIFF
--- a/Documentation/teaching/labs/kernel_api.rst
+++ b/Documentation/teaching/labs/kernel_api.rst
@@ -139,8 +139,8 @@ For failures, negative values are returned as shown in the example below:
        return -EINVAL;
 
 The exhaustive list of errors and a summary explanation can be found in
-:file:`include/asm-generic/errno-base.h` and in
-:file:`includes/asm-generic/ernno.h`.
+:file:`include/uapi/asm-generic/errno-base.h` and in
+:file:`include/uapi/asm-generic/ernno.h`.
 
 Strings of characters
 ---------------------

--- a/Documentation/teaching/labs/kernel_modules.rst
+++ b/Documentation/teaching/labs/kernel_modules.rst
@@ -386,7 +386,7 @@ Next line
 Tells us that it's the first oops (#1). This is important in the context that
 an oops can lead to other oopses. Usually only the first oops is relevant.
 Furthermore, the oops code (``0002``) provides information about the error type
-(see :file:`arch/x86/include/asm/traps.h`):
+(see :file:`arch/x86/include/asm/trap_pf.h`):
 
 
    * Bit 0 == 0 means no page found, 1 means protection fault
@@ -558,7 +558,7 @@ A more simplistic way to find the code that generated an oops is to use the
    /root/lab-01/modul-oops/oops.c:23
 
 Where ``0x5`` is the value of the program counter (``EIP = c89d4005``) that
-generated the oops, minus the base address of the module (``0xc89c4000``)
+generated the oops, minus the base address of the module (``0xc89d4000``)
 according to :file:`/proc/modules`
 
 minicom


### PR DESCRIPTION
- Correct base address of module in kernel oops debugging example
- Reference current file containing description of page fault error code bits