### PR TITLE
Documentation: filesystems_part2: fix typos

### DIFF
--- a/Documentation/teaching/labs/filesystems_part2.rst
+++ b/Documentation/teaching/labs/filesystems_part2.rst
@@ -432,7 +432,7 @@ This function is called by the ``mkdir`` system call. Such a function performs t
 Creating a link
 ---------------
 
-The link creation function (hard link) is indicated by the ``symlink`` field in the ``inode_operations`` structure.
+The link creation function (hard link) is indicated by the ``link`` field in the ``inode_operations`` structure.
 In the minix case, the function is :c:func:`minix_link`.
 This function is called by the ``link`` system call. Such a function performs the following operations:
 


### PR DESCRIPTION
https://github.com/linux-kernel-labs/linux/blob/766862ca5a9ae17541541ea0cecac7c8810105b7/Documentation/teaching/labs/filesystems_part2.rst?plain=1#L376-L389

https://github.com/linux-kernel-labs/linux/blob/766862ca5a9ae17541541ea0cecac7c8810105b7/Documentation/teaching/labs/filesystems_part2.rst?plain=1#L432-L436

`minix_link` correspond to `link` in the first snippet, so the `simlink` should be modified to `link` in the second snippet