### PR TITLE
Using old sphnix_rtd_theme package for docker-docs target

### DIFF
--- a/tools/labs/docker/docs/Dockerfile
+++ b/tools/labs/docker/docs/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get install -y fonts-noto-cjk
 RUN apt-get install -y latexmk
 RUN apt-get install -y librsvg2-bin
 RUN apt-get install -y texlive-xetex
-RUN pip install Sphinx==1.6.7 sphinx_rtd_theme hieroglyph==1.0 Jinja2==2.11.3 markupsafe==2.0.1
+RUN pip install Sphinx==1.6.7 sphinx_rtd_theme==1.3.0 hieroglyph==1.0 Jinja2==2.11.3 markupsafe==2.0.1
 # append new packages here, to minimize docker rebuild time
 RUN rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
The same issue reported in [#378 ](url).
Fix it by using sphinx_rtd_theme version 1.3.0 in docs/Dockerfile