### PR TITLE
Added FirewallD support to scripts

### DIFF
--- a/tools/labs/qemu/cleanup-net.sh
+++ b/tools/labs/qemu/cleanup-net.sh
@@ -2,13 +2,16 @@
 
 DNSMASQ=/tmp/dnsmasq
 
-for i in lkt-tap0 lkt-tap1 lkt-tap-smbd; do
-  if ! ip a s dev &> /dev/null $i; then
+for device in lkt-tap0 lkt-tap1 lkt-tap-smbd; do
+  if ! ip a s dev &> /dev/null $device; then
     continue
   fi
-  if [ -f $DNSMASQ-$i.pid ]; then
-    sudo kill `cat $DNSMASQ-$i.pid`
+  if [ -f $DNSMASQ-$device.pid ]; then
+    sudo kill $(cat $DNSMASQ-$device.pid)
   fi
-  sudo rm $DNSMASQ-$i.leases
-  sudo ip tuntap del $i mode tap
+  sudo rm $DNSMASQ-$device.leases
+  if [ -e $(which --skip-alias firewall-cmd) ]; then
+    sudo firewall-cmd --zone=trusted --remove-interface=$device
+  fi
+  sudo ip tuntap del $device mode tap
 done

--- a/tools/labs/qemu/create_net.sh
+++ b/tools/labs/qemu/create_net.sh
@@ -37,6 +37,10 @@ sudo /sbin/ip link set dev "$device" down
 sudo /sbin/ip address add $subnet.1/24 dev "$device"
 sudo /sbin/ip link set dev "$device" up
 
+if [ -e $(which --skip-alias firewall-cmd) ]; then
+    sudo firewall-cmd --zone=trusted --change-interface=$device
+fi
+
 sudo dnsmasq --port=0 --no-resolv --no-hosts --bind-interfaces \
   --interface $device -F $subnet.2,$subnet.20 --listen-address $subnet.1 \
   -x /tmp/dnsmasq-$device.pid -l /tmp/dnsmasq-$device.leases || true


### PR DESCRIPTION
The default action on Fedora and RHEL-based distributions that use FirewallD is to ban DHCP requests. Instead of telling people to turn off their firewall, I recommend adding the tap interfaces to the FirewallD trusted zone.

This commit adds automatic support to the create_net.sh and cleanup-net.sh scripts that set up the tap interfaces. Due to many distributions using FirewallD these days, I opted for using the following command to check if FirewallD is available:

```bash
if [ -e $(which firewall-cmd) ]; then
    sudo firewall-cmd --zone=trusted --change-interface=$device
fi
```

However, we will have to create a better solution for this in the future.